### PR TITLE
RocketMQ-Go-Client-Init

### DIFF
--- a/rocketmq-go/docs/package.puml
+++ b/rocketmq-go/docs/package.puml
@@ -1,0 +1,67 @@
+@startuml
+class rocketmq.MqClientManager{
+RebalanceController
+serviceState
+}
+class rocketmq.ClientFactory{
+mqConsumerTable
+mqProducerTable
+}
+class rocketmq.MqConsumer{
+serviceState
+offsetStore
+}
+class rocketmq.MqProducer{
+serviceState
+ }
+ class client.MqClient{
+
+
+ }
+  class remoting.RemotingClient{
+   invokeSync
+   invokeAsync
+   invokeOneWay
+  }
+ class remoting.RemotingCommand{
+  customHeader
+  requestCode
+  responseCode
+ }
+  class remoting.ClientConfig{
+   nameSrvAddr
+   clientIP
+   instanceName
+  }
+namespace rocketmq{
+
+MqClientManager *-- PullMessageController:contains
+MqClientManager *-- RebalanceController:contains
+MqClientManager *-- ClientFactory:contains
+MqClientManager *-- SomeTask
+SomeTask *-- ClientFactory:contains
+PullMessageController *-- ClientFactory:contains
+RebalanceController *-- ClientFactory:contains
+ClientFactory *-- MqProducer:contains
+ClientFactory *-- MqConsumer:contains
+MqProducer *-- client.MqClient :contains
+MqConsumer *-- client.MqClient : contains
+MqConsumer *-- client.OffsetStore : contains
+'client.RebalanceController *-- remoting.RemotingClient : contains
+'client.PullMessageController *-- remoting.RemotingClient :contains
+}
+
+namespace client{
+    MqClient o-- remoting.RemotingClient:contains
+    OffsetStore o-- MqClient
+}
+
+namespace remoting {
+  RemotingClient  *-- RemotingCommand:contains
+  RemotingClient *-- ClientConfig:contains
+
+}
+note top of remoting.RemotingClient :（sync|aysc|oneWay）
+note top of remoting :net，serialize，connect，request response
+note top of client.MqClient :mq method
+@enduml

--- a/rocketmq-go/docs/package.puml
+++ b/rocketmq-go/docs/package.puml
@@ -1,20 +1,24 @@
 @startuml
-class rocketmq.MqClientManager{
-RebalanceController
+
+
+class rocketmq_go.MqClientManager{
 serviceState
 }
-class rocketmq.ClientFactory{
+class rocketmq_go.PullMessageController{
+
+}
+class rocketmq_go.ClientFactory{
 mqConsumerTable
 mqProducerTable
 }
-class rocketmq.MqConsumer{
+class service.MqConsumer{
 serviceState
 offsetStore
 }
-class rocketmq.MqProducer{
+class service.MqProducer{
 serviceState
  }
- class client.MqClient{
+ class service.MqClient{
 
 
  }
@@ -33,35 +37,43 @@ serviceState
    clientIP
    instanceName
   }
-namespace rocketmq{
+namespace service{
 
-MqClientManager *-- PullMessageController:contains
-MqClientManager *-- RebalanceController:contains
-MqClientManager *-- ClientFactory:contains
-MqClientManager *-- SomeTask
-SomeTask *-- ClientFactory:contains
-PullMessageController *-- ClientFactory:contains
-RebalanceController *-- ClientFactory:contains
-ClientFactory *-- MqProducer:contains
-ClientFactory *-- MqConsumer:contains
-MqProducer *-- client.MqClient :contains
-MqConsumer *-- client.MqClient : contains
-MqConsumer *-- client.OffsetStore : contains
-'client.RebalanceController *-- remoting.RemotingClient : contains
-'client.PullMessageController *-- remoting.RemotingClient :contains
+
+rocketmq_go.PullMessageController *-- rocketmq_go.ClientFactory:contains
+rocketmq_go.ClientFactory *-- MqProducer:contains
+rocketmq_go.ClientFactory *-- MqConsumer:contains
+MqProducer *-- service.MqClient :contains
+MqConsumer *-- service.MqClient : contains
+MqConsumer *-- service.OffsetStore : contains
+MqConsumer *-- service.Rebalance : contains
+MqConsumer *-- service.ConsumeMessageService : contains
+
 }
 
-namespace client{
+namespace service{
     MqClient o-- remoting.RemotingClient:contains
     OffsetStore o-- MqClient
+    Rebalance o-- MqClient
+    Rebalance o-- OffsetStore
+    ConsumeMessageService o-- SendMessageBackProducerService
+    ConsumeMessageService o-- OffsetStore
 }
 
 namespace remoting {
   RemotingClient  *-- RemotingCommand:contains
   RemotingClient *-- ClientConfig:contains
 
+
 }
+
+namespace rocketmq_go{
+    MqClientManager o-- PullMessageController
+    MqClientManager o-- ClientFactory
+}
+
+
 note top of remoting.RemotingClient :（sync|aysc|oneWay）
 note top of remoting :net，serialize，connect，request response
-note top of client.MqClient :mq method
+note top of service.MqClient :mq method
 @enduml

--- a/rocketmq-go/docs/roadmap.md
+++ b/rocketmq-go/docs/roadmap.md
@@ -1,4 +1,4 @@
-# Roadmap
+# RoadMap-ALL
 
 ## Producer
 - [ ] ProducerType
@@ -96,3 +96,71 @@
 - [ ] Other
     - [ ] VIPChannel
     - [ ] RPCHook
+    
+    
+# RoadMap-Milestone1
+
+## Producer
+- [ ] ProducerType
+    - [ ] DefaultProducer
+- [ ] API
+    - [ ] Send
+        - [ ] Sync
+- [ ] Other
+    - [ ] DelayMessage
+    - [ ] Config
+    - [ ] MessageId Generate
+    - [ ] CompressMsg
+    - [ ] TimeOut
+    - [ ] LoadBalance
+    - [ ] DefaultTopic
+## Consumer
+- [ ] ConsumerType
+    - [ ] PushConsumer
+- [ ] MessageListener
+    - [ ] Concurrently
+- [ ] MessageModel
+    - [ ] CLUSTERING
+- [ ] OffsetStore
+    - [ ] RemoteBrokerOffsetStore
+- [ ] RebalanceService
+- [ ] PullMessageService
+- [ ] ConsumeMessageService
+- [ ] AllocateMessageQueueStrategy
+    - [ ] AllocateMessageQueueAveragely
+- [ ] Other
+    - [ ] Config
+    - [ ] ZIP
+    - [ ] ConsumeFromWhere
+        - [ ] CONSUME_FROM_LAST_OFFSET
+        - [ ] CONSUME_FROM_FIRST_OFFSET
+        - [ ] CONSUME_FROM_TIMESTAMP
+    - [ ] Retry(sendMessageBack)
+    - [ ] TimeOut(clearExpiredMessage)
+    - [ ] ACK(partSuccess)
+    - [ ] FlowControl(messageCanNotConsume)
+## Manager
+- [ ] Controller
+    - [ ] PullMessageController
+- [ ] Task
+    - [ ] Heartbeat
+    - [ ] UpdateTopicRouteInfoFromNameServer
+    - [ ] PersistAllConsumerOffset
+    - [ ] ClearExpiredMessage(form consumer consumeMessageService)
+
+
+## Remoting
+- [ ] MqClientRequest
+    - [ ] InvokeSync
+    - [ ] InvokeAsync
+    - [ ] InvokeOneWay
+- [ ] ClientRemotingProcessor
+    - [ ] NOTIFY_CONSUMER_IDS_CHANGED
+    - [ ] RESET_CONSUMER_CLIENT_OFFSET
+    - [ ] GET_CONSUMER_STATUS_FROM_CLIENT
+    - [ ] GET_CONSUMER_RUNNING_INFO
+    - [ ] CONSUME_MESSAGE_DIRECTLY
+- [ ] Serialize
+    - [ ] JSON
+    - [ ] ROCKETMQ
+- [ ] NamesrvAddrChoosed(HA)

--- a/rocketmq-go/docs/roadmap.md
+++ b/rocketmq-go/docs/roadmap.md
@@ -1,3 +1,71 @@
+# RoadMap-Milestone1
+
+## Producer
+- [ ] ProducerType
+    - [ ] DefaultProducer
+- [ ] API
+    - [ ] Send
+        - [ ] Sync
+- [ ] Other
+    - [ ] DelayMessage
+    - [ ] Config
+    - [ ] MessageId Generate
+    - [ ] CompressMsg
+    - [ ] TimeOut
+    - [ ] LoadBalance
+    - [ ] DefaultTopic
+## Consumer
+- [ ] ConsumerType
+    - [ ] PushConsumer
+- [ ] MessageListener
+    - [ ] Concurrently
+- [ ] MessageModel
+    - [ ] CLUSTERING
+- [ ] OffsetStore
+    - [ ] RemoteBrokerOffsetStore
+- [ ] RebalanceService
+- [ ] PullMessageService
+- [ ] ConsumeMessageService
+- [ ] AllocateMessageQueueStrategy
+    - [ ] AllocateMessageQueueAveragely
+- [ ] Other
+    - [ ] Config
+    - [ ] ZIP
+    - [ ] ConsumeFromWhere
+        - [ ] CONSUME_FROM_LAST_OFFSET
+        - [ ] CONSUME_FROM_FIRST_OFFSET
+        - [ ] CONSUME_FROM_TIMESTAMP
+    - [ ] Retry(sendMessageBack)
+    - [ ] TimeOut(clearExpiredMessage)
+    - [ ] ACK(partSuccess)
+    - [ ] FlowControl(messageCanNotConsume)
+## Manager
+- [ ] Controller
+    - [ ] PullMessageController
+- [ ] Task
+    - [ ] Heartbeat
+    - [ ] UpdateTopicRouteInfoFromNameServer
+    - [ ] PersistAllConsumerOffset
+    - [ ] ClearExpiredMessage(form consumer consumeMessageService)
+
+
+## Remoting
+- [ ] MqClientRequest
+    - [ ] InvokeSync
+    - [ ] InvokeAsync
+    - [ ] InvokeOneWay
+- [ ] ClientRemotingProcessor
+    - [ ] NOTIFY_CONSUMER_IDS_CHANGED
+    - [ ] RESET_CONSUMER_CLIENT_OFFSET
+    - [ ] GET_CONSUMER_STATUS_FROM_CLIENT
+    - [ ] GET_CONSUMER_RUNNING_INFO
+    - [ ] CONSUME_MESSAGE_DIRECTLY
+- [ ] Serialize
+    - [ ] JSON
+    - [ ] ROCKETMQ
+- [ ] NamesrvAddrChoosed(HA)
+
+
 # RoadMap-ALL
 
 ## Producer
@@ -98,69 +166,3 @@
     - [ ] RPCHook
     
     
-# RoadMap-Milestone1
-
-## Producer
-- [ ] ProducerType
-    - [ ] DefaultProducer
-- [ ] API
-    - [ ] Send
-        - [ ] Sync
-- [ ] Other
-    - [ ] DelayMessage
-    - [ ] Config
-    - [ ] MessageId Generate
-    - [ ] CompressMsg
-    - [ ] TimeOut
-    - [ ] LoadBalance
-    - [ ] DefaultTopic
-## Consumer
-- [ ] ConsumerType
-    - [ ] PushConsumer
-- [ ] MessageListener
-    - [ ] Concurrently
-- [ ] MessageModel
-    - [ ] CLUSTERING
-- [ ] OffsetStore
-    - [ ] RemoteBrokerOffsetStore
-- [ ] RebalanceService
-- [ ] PullMessageService
-- [ ] ConsumeMessageService
-- [ ] AllocateMessageQueueStrategy
-    - [ ] AllocateMessageQueueAveragely
-- [ ] Other
-    - [ ] Config
-    - [ ] ZIP
-    - [ ] ConsumeFromWhere
-        - [ ] CONSUME_FROM_LAST_OFFSET
-        - [ ] CONSUME_FROM_FIRST_OFFSET
-        - [ ] CONSUME_FROM_TIMESTAMP
-    - [ ] Retry(sendMessageBack)
-    - [ ] TimeOut(clearExpiredMessage)
-    - [ ] ACK(partSuccess)
-    - [ ] FlowControl(messageCanNotConsume)
-## Manager
-- [ ] Controller
-    - [ ] PullMessageController
-- [ ] Task
-    - [ ] Heartbeat
-    - [ ] UpdateTopicRouteInfoFromNameServer
-    - [ ] PersistAllConsumerOffset
-    - [ ] ClearExpiredMessage(form consumer consumeMessageService)
-
-
-## Remoting
-- [ ] MqClientRequest
-    - [ ] InvokeSync
-    - [ ] InvokeAsync
-    - [ ] InvokeOneWay
-- [ ] ClientRemotingProcessor
-    - [ ] NOTIFY_CONSUMER_IDS_CHANGED
-    - [ ] RESET_CONSUMER_CLIENT_OFFSET
-    - [ ] GET_CONSUMER_STATUS_FROM_CLIENT
-    - [ ] GET_CONSUMER_RUNNING_INFO
-    - [ ] CONSUME_MESSAGE_DIRECTLY
-- [ ] Serialize
-    - [ ] JSON
-    - [ ] ROCKETMQ
-- [ ] NamesrvAddrChoosed(HA)

--- a/rocketmq-go/docs/roadmap.md
+++ b/rocketmq-go/docs/roadmap.md
@@ -1,0 +1,98 @@
+# Roadmap
+
+## Producer
+- [ ] ProducerType
+    - [ ] DefaultProducer
+    - [ ] TransactionProducer
+- [ ] API
+    - [ ] Send
+        - [ ] Sync
+        - [ ] Async
+        - [ ] OneWay
+- [ ] Other
+    - [ ] DelayMessage
+    - [ ] Config
+    - [ ] MessageId Generate
+    - [ ] CompressMsg
+    - [ ] TimeOut
+    - [ ] LoadBalance
+    - [ ] DefaultTopic
+    - [ ] VipChannel
+    - [ ] Retry
+    - [ ] SendMessageHook
+    - [ ] CheckRequestQueue
+    - [ ] CheckForbiddenHookList
+    - [ ] MQFaultStrategy
+
+
+
+## Consumer
+- [ ] ConsumerType
+    - [ ] PushConsumer
+    - [ ] PullConsumer
+- [ ] MessageListener
+    - [ ] Concurrently
+    - [ ] Orderly
+- [ ] MessageModel
+    - [ ] CLUSTERING
+    - [ ] BROADCASTING
+- [ ] OffsetStore
+    - [ ] RemoteBrokerOffsetStore
+        - [ ] many actions
+    - [ ] LocalFileOffsetStore
+- [ ] RebalanceService
+- [ ] PullMessageService
+- [ ] ConsumeMessageService
+- [ ] AllocateMessageQueueStrategy
+    - [ ] AllocateMessageQueueAveragely
+    - [ ] AllocateMessageQueueAveragelyByCircle
+    - [ ] AllocateMessageQueueByConfig
+    - [ ] AllocateMessageQueueByMachineRoom
+- [ ] Other
+    - [ ] Config
+    - [ ] ZIP
+    - [ ] AllocateMessageQueueStrategy
+    - [ ] ConsumeFromWhere
+        - [ ] CONSUME_FROM_LAST_OFFSET
+        - [ ] CONSUME_FROM_FIRST_OFFSET
+        - [ ] CONSUME_FROM_TIMESTAMP
+    - [ ] Retry(sendMessageBack)
+    - [ ] TimeOut(clearExpiredMessage)
+    - [ ] ACK(partSuccess)
+    - [ ] FlowControl(messageCanNotConsume)
+    - [ ] ConsumeMessageHook
+    - [ ] filterMessageHookList
+
+## Manager
+- [ ] Controller
+    - [ ] RebalanceController
+    - [ ] PullMessageController
+- [ ] Task
+    - [ ] PollNameServer
+    - [ ] Heartbeat
+    - [ ] UpdateTopicRouteInfoFromNameServer
+    - [ ] CleanOfflineBroker
+    - [ ] PersistAllConsumerOffset
+    - [ ] ClearExpiredMessage(form consumer consumeMessageService)
+    - [ ] UploadFilterClassSource(FromHeartBeat/But Golang Not Easy To do this(Java Source))
+
+
+## Remoting
+- [ ] MqClientRequest
+    - [ ] InvokeSync
+    - [ ] InvokeAsync
+    - [ ] InvokeOneWay
+- [ ] ClientRemotingProcessor
+    - [ ] CHECK_TRANSACTION_STATE
+    - [ ] NOTIFY_CONSUMER_IDS_CHANGED
+    - [ ] RESET_CONSUMER_CLIENT_OFFSET
+    - [ ] GET_CONSUMER_STATUS_FROM_CLIENT
+    - [ ] GET_CONSUMER_RUNNING_INFO
+    - [ ] CONSUME_MESSAGE_DIRECTLY
+- [ ] Serialize
+    - [ ] JSON
+    - [ ] ROCKETMQ
+- [ ] NamesrvAddrChoosed(HA)
+- [ ] Other
+    - [ ] VIPChannel
+    - [ ] RPCHook

--- a/rocketmq-go/example/consumer_example.go
+++ b/rocketmq-go/example/consumer_example.go
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package example
+
+func main() {
+}

--- a/rocketmq-go/example/producer_example.go
+++ b/rocketmq-go/example/producer_example.go
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package example

--- a/rocketmq-go/model/config/consumer_config.go
+++ b/rocketmq-go/model/config/consumer_config.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package config
+
+type RocketMqConsumerConfig struct {
+
+}

--- a/rocketmq-go/model/config/producer_config.go
+++ b/rocketmq-go/model/config/producer_config.go
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package config
+type RocketMqProducerConfig struct {
+
+}

--- a/rocketmq-go/model/config/rocketmq_config.go
+++ b/rocketmq-go/model/config/rocketmq_config.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package config
+type RocketMqClientConfig struct {
+
+}
+

--- a/rocketmq-go/model/constant/message_constant.go
+++ b/rocketmq-go/model/constant/message_constant.go
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package header

--- a/rocketmq-go/model/header/pull_message_request_header.go
+++ b/rocketmq-go/model/header/pull_message_request_header.go
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package header
+
+type PullMessageRequestHeader struct {
+}
+
+func (self *PullMessageRequestHeader) FromMap(headerMap map[string]interface{}) {
+	return
+}

--- a/rocketmq-go/model/header/send_message_response_header.go
+++ b/rocketmq-go/model/header/send_message_response_header.go
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package header
+
+type SendMessageResponseHeader struct {
+	MsgId         string
+	QueueId       int32
+	QueueOffset   int64
+	TransactionId string
+	MsgRegion     string
+}
+
+func (self *SendMessageResponseHeader) FromMap(headerMap map[string]interface{}) {
+	return
+}

--- a/rocketmq-go/model/send_result.go
+++ b/rocketmq-go/model/send_result.go
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package model
+
+type SendResult struct {
+}

--- a/rocketmq-go/mq_client_manager.go
+++ b/rocketmq-go/mq_client_manager.go
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package rocketmq_go
+
+import "github.com/incubator-rocketmq-externals/rocketmq-go/service"
+
+type MqClientManager struct {
+	clientFactory          *ClientFactory
+	rocketMqClient         service.RocketMqClient
+	pullMessageController  *PullMessageController
+	defaultProducerService RocketMQProducer //for send back message
+}
+
+type ClientFactory struct {
+	ProducerTable map[string]RocketMQProducer //group|RocketMQProducer
+	ConsumerTable map[string]RocketMQConsumer //group|Consumer
+}
+
+type PullMessageController struct {
+	rocketMqClient service.RocketMqClient
+	clientFactory  *ClientFactory
+}

--- a/rocketmq-go/mq_consumer.go
+++ b/rocketmq-go/mq_consumer.go
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package rocketmq_go
+
+import "github.com/incubator-rocketmq-externals/rocketmq-go/service"
+
+type RocketMQConsumer interface {
+}
+
+type MqConsumerConfig struct {
+
+}
+type DefaultMQPushConsumer struct {
+	offsetStore           service.OffsetStore //for consumer's offset
+	mqClient              service.RocketMqClient
+	rebalance             *service.Rebalance  //Rebalance's impl depend on offsetStore
+	consumeMessageService service.ConsumeMessageService
+	ConsumerConfig        *MqConsumerConfig
+}
+
+

--- a/rocketmq-go/mq_producer.go
+++ b/rocketmq-go/mq_producer.go
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package rocketmq_go
+
+import "github.com/incubator-rocketmq-externals/rocketmq-go/service"
+
+type RocketMQProducer interface {
+}
+
+type MqProducerConfig struct {
+
+}
+
+type DefaultMQProducer struct {
+	producerGroup   string
+	ProducerConfig  *MqProducerConfig
+	producerService service.ProducerService
+}

--- a/rocketmq-go/remoting/custom_header.go
+++ b/rocketmq-go/remoting/custom_header.go
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package remoting
+type CustomerHeader interface {
+	FromMap(headerMap map[string]interface{})
+}

--- a/rocketmq-go/remoting/invoke_callback.go
+++ b/rocketmq-go/remoting/invoke_callback.go
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package remoting
+type ResponseFuture struct {
+}
+type InvokeCallback func(responseFuture *ResponseFuture)

--- a/rocketmq-go/remoting/remoting_client.go
+++ b/rocketmq-go/remoting/remoting_client.go
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package remoting
+
+type DefalutRemotingClient struct {
+}
+
+func (self *DefalutRemotingClient) InvokeSync(addr string, request *RemotingCommand, timeoutMillis int64) (remotingCommand *RemotingCommand, err error) {
+	return
+}
+func (self *DefalutRemotingClient)InvokeAsync(addr string, request *RemotingCommand, timeoutMillis int64, invokeCallback InvokeCallback) error {
+	return
+}
+func (self *DefalutRemotingClient)InvokeOneWay(addr string, request *RemotingCommand, timeoutMillis int64) error {
+	return
+}

--- a/rocketmq-go/remoting/remoting_command.go
+++ b/rocketmq-go/remoting/remoting_command.go
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package remoting
+
+type RemotingCommand struct {
+}
+
+

--- a/rocketmq-go/service/consume_messsage_service.go
+++ b/rocketmq-go/service/consume_messsage_service.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package service
+
+type ConsumeMessageService struct {
+
+}

--- a/rocketmq-go/service/mq_client.go
+++ b/rocketmq-go/service/mq_client.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package service
+
+type RocketMqClient interface {
+
+}

--- a/rocketmq-go/service/offset_store_service.go
+++ b/rocketmq-go/service/offset_store_service.go
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package service
+
+type OffsetStore struct {
+	mqClient RocketMqClient
+}

--- a/rocketmq-go/service/producer_service.go
+++ b/rocketmq-go/service/producer_service.go
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package service
+
+import "github.com/incubator-rocketmq-externals/rocketmq-go/model/config"
+type ProducerService interface {
+}
+type DefaultProducerService struct {
+	producerGroup   string
+	producerConfig  *config.RocketMqProducerConfig
+	mqClient        RocketMqClient
+}

--- a/rocketmq-go/service/rebalance_service.go
+++ b/rocketmq-go/service/rebalance_service.go
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package service
+
+import "github.com/incubator-rocketmq-externals/rocketmq-go/model/config"
+
+type Rebalance struct {
+	mqClient       RocketMqClient
+	offsetStore    OffsetStore
+	consumerConfig config.RocketMqClientConfig
+}


### PR DESCRIPTION
Add rocketmq go client's design, roadmap and package.
![alternative text](http://www.plantuml.com/plantuml/proxy?src=https://raw.githubusercontent.com/StyleTang/incubator-rocketmq-externals/go-client-init/rocketmq-go/docs/package.puml)
